### PR TITLE
Remove links

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,7 @@ be delayed in `@INC` inclusion.
 You can look for additional information at:
 
 - [GitHub](https://github.com/gryphonshafer/exact)
-- [CPAN](http://search.cpan.org/dist/exact)
 - [MetaCPAN](https://metacpan.org/pod/exact)
-- [AnnoCPAN](http://annocpan.org/dist/exact)
 - [Travis CI](https://travis-ci.org/gryphonshafer/exact)
 - [Coveralls](https://coveralls.io/r/gryphonshafer/exact)
 - [CPANTS](http://cpants.cpanauthors.org/dist/exact)

--- a/lib/exact.pm
+++ b/lib/exact.pm
@@ -422,9 +422,7 @@ You can look for additional information at:
 
 =for :list
 * L<GitHub|https://github.com/gryphonshafer/exact>
-* L<CPAN|http://search.cpan.org/dist/exact>
 * L<MetaCPAN|https://metacpan.org/pod/exact>
-* L<AnnoCPAN|http://annocpan.org/dist/exact>
 * L<Travis CI|https://travis-ci.org/gryphonshafer/exact>
 * L<Coveralls|https://coveralls.io/r/gryphonshafer/exact>
 * L<CPANTS|http://cpants.cpanauthors.org/dist/exact>


### PR DESCRIPTION
AnnoCPAN is gone and serch.cpan.org is redirected to metacpan.